### PR TITLE
Create role for Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
   macos:
     name: Test playbook on macOS
-    runs-on: macOS-latest
+    runs-on: macos-latest
     
     steps:
       - uses: actions/checkout@v1
@@ -27,7 +27,10 @@ jobs:
         run: sudo easy_install pip
       
       - name: Install Ansible
-        run: sudo pip install ansible 
+        run: sudo pip install ansible
+
+      - name: Copy variables.
+        run: cp variables.example.yml variables.yml
 
       - name: Test playbook
         run: ansible-playbook workstation.yml
@@ -42,5 +45,8 @@ jobs:
       - name: Install Ansible
         run: sudo apt-get install ansible
       
+      - name: Copy variables.
+        run: cp variables.example.yml variables.yml
+
       - name: Test playbook
         run: ansible-playbook workstation.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the variables file, which may contain sensitive information.
+variables.yml

--- a/roles/git/tasks/config.yml
+++ b/roles/git/tasks/config.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Configure Git user name.
+  git_config:
+    name: user.name
+    scope: global
+    value: "{{ git.username }}"
+
+- name: Configure Git user email.
+  git_config:
+    name: user.email
+    scope: global
+    value: "{{ git.email }}"
+
+- name: Set current branch as default push target.
+  git_config:
+      name: push.default
+      scope: global
+      value: current

--- a/roles/git/tasks/macos.yml
+++ b/roles/git/tasks/macos.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Install Git.
+  homebrew:
+    name: git
+    state: present

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- include: macos.yml
+  when: ansible_os_family == 'Darwin'
+  tags:
+    - desktop
+    - git
+    - terminal
+
+- include: ubuntu.yml
+  when: ansible_os_family == 'Debian'
+  tags:
+    - desktop
+    - git
+    - terminal
+
+- include: config.yml
+  tags:
+    - desktop
+    - git
+    - terminal

--- a/roles/git/tasks/ubuntu.yml
+++ b/roles/git/tasks/ubuntu.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install Git.
+  apt:
+    name: git
+    state: present
+    update_cache: "yes"
+  become: "yes"

--- a/variables.example.yml
+++ b/variables.example.yml
@@ -1,0 +1,3 @@
+git:
+  username: John Doe
+  email: john@example.com

--- a/workstation.yml
+++ b/workstation.yml
@@ -2,10 +2,10 @@
 
 - hosts: localhost
 
-  tasks:
-    - debug:
-        msg: Running Ansible on {{ ansible_facts['nodename'] }}
+  vars_files:
+    - variables.yml
 
   roles:
     - command_line_tools
     - package_manager
+    - git


### PR DESCRIPTION
A new role for Git has been created. First, Git is installed through the
package manager (Homebrew or apt), and then configured.