### PR TITLE
Create role for neovim

### DIFF
--- a/roles/neovim/tasks/config.yml
+++ b/roles/neovim/tasks/config.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Copy neovim configuration.
+  template:
+    src: "templates/init.vim.j2"
+    dest: "{{ ansible_env['HOME'] }}/.config/nvim/init.vim"
+
+- name: Set neovim as default editor in fish.
+  template:
+    src: "templates/neovim.fish.j2"
+    dest: "{{ fish_config_directory }}/neovim.fish"
+

--- a/roles/neovim/tasks/macos.yml
+++ b/roles/neovim/tasks/macos.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Install neovim.
+  homebrew:
+    name: neovim
+    state: present

--- a/roles/neovim/tasks/main.yml
+++ b/roles/neovim/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- include_tasks: macos.yml
+  when: ansible_os_family == 'Darwin'
+  tags:
+    - desktop
+    - neovim
+    - terminal
+
+- include_tasks: ubuntu.yml
+  when: ansible_os_family == 'Debian'
+  tags:
+    - desktop
+    - neovim
+    - terminal
+
+- include_tasks: config.yml
+  tags:
+    - desktop
+    - neovim
+    - terminal

--- a/roles/neovim/tasks/ubuntu.yml
+++ b/roles/neovim/tasks/ubuntu.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install neovim.
+  apt:
+    name: neovim
+    state: present
+    update_cache: "yes"
+  become: "yes"

--- a/roles/neovim/templates/init.vim.j2
+++ b/roles/neovim/templates/init.vim.j2
@@ -1,0 +1,13 @@
+" Disable Arrow keys in Escape mode
+map <up> <nop>
+map <down> <nop>
+map <left> <nop>
+map <right> <nop>
+
+set number relativenumber
+
+augroup numbertoggle
+  autocmd!
+  autocmd BufEnter,FocusGained,InsertLeave * set relativenumber
+  autocmd BufLeave,FocusLost,InsertEnter   * set norelativenumber
+augroup END

--- a/roles/neovim/templates/neovim.fish.j2
+++ b/roles/neovim/templates/neovim.fish.j2
@@ -1,0 +1,2 @@
+# Neovim for the win
+set -Ux EDITOR nvim


### PR DESCRIPTION
neovim is the editor of choice. A role has been added that installs
neovim, configures it, and makes it the default editor in fish.