### PR TITLE
Create bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 This repository contains my [Ansible] playbook to automatically provision new
 workstations and servers. It is very opinionated and tailored to my own needs.
+
 Feel free to use it as inspiration and fork it.
+
+## Getting Started
+
+The repository contains a [bootstrap script](bin/bootstrap) for macOS that can
+be run on a fresh machine. It installs [Homebrew] and [Ansible], and then runs
+the playbook with `ansible-pull`.
+
+Open a terminal and run the following command. You will be prompted for your
+password once so that [Homebrew] can be installed.
+
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/jdno/workstation/HEAD/bin/bootstrap)"
+```
 
 ## License
 
@@ -10,4 +24,5 @@ This project is licensed under the terms of the [MIT License][mit]. See
 [LICENSE](./LICENSE) for more information.
 
 [ansible]: https://www.ansible.com/
+[homebrew]: https://brew.sh
 [mit]: https://opensource.org/licenses/MIT

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Enable strict mode for Bash
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+# Install Homebrew
+if ! command -v brew &>/dev/null; then
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+# Install ansible-pull
+if ! command -v ansible-pull &>/dev/null; then
+	brew install ansible
+fi
+
+echo "Done."


### PR DESCRIPTION
A minimal bootstrap script for macOS has been added to the project. It can be used to provision a new machine right after it has been installed. The script first sets up Homebrew, and then uses that to install Ansible.