### PR TITLE
Enable colors output from Ansible

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -15,4 +15,4 @@ if ! command -v ansible-pull &>/dev/null; then
 	brew install ansible
 fi
 
-ansible-pull -K -U https://github.com/jdno/workstation.git
+ANSIBLE_FORCE_COLOR=1 ansible-pull -K -U https://github.com/jdno/workstation.git


### PR DESCRIPTION
When running Ansible through the bootstrap script, its output was not colored and thus hard to read. Ansible is now run with a flag that enables colored output to fix this.