### PR TITLE
Lint Ansible playbooks

### DIFF
--- a/.github/workflows/push-ansible.yml
+++ b/.github/workflows/push-ansible.yml
@@ -1,0 +1,24 @@
+---
+name: Ansible
+
+"on":
+  push:
+    paths:
+      - "roles/"
+      - "ansible.cfg"
+      - "hosts"
+      - "local.yml"
+
+jobs:
+  lint:
+    name: Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ansible Lint
+        uses: ansible-community/ansible-lint-action@v6.2.1
+        with:
+          path: local.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
+    rev: v2.7.0
     hooks:
       - id: prettier
   - repo: https://github.com/doublify/pre-commit-rust
@@ -45,3 +45,7 @@ repos:
         name: shellcheck
       - id: shfmt
         name: shfmt
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v6.3.0
+    hooks:
+      - id: ansible-lint

--- a/local.yml
+++ b/local.yml
@@ -5,5 +5,5 @@
 
   tasks:
     - name: print hello world
-      debug:
+      ansible.builtin.debug:
         msg: "Hello, World!"


### PR DESCRIPTION
Ansible ships with its own linter, which is being run both as a pre-commit hook and a GitHub Action to ensure that the playbooks avoid common mistakes and follow the best practices of the community.