### PR TITLE
Set up Homebrew

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - ~/.ansible

--- a/local.yml
+++ b/local.yml
@@ -1,9 +1,7 @@
 ---
 - hosts: localhost
   connection: local
-  become: true
 
-  tasks:
-    - name: print hello world
-      ansible.builtin.debug:
-        msg: "Hello, World!"
+  roles:
+    - role: elliotweiser.osx-command-line-tools
+    - role: geerlingguy.mac.homebrew

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+roles:
+  - name: elliotweiser.osx-command-line-tools
+
+collections:
+  - name: geerlingguy.mac


### PR DESCRIPTION
The playbook has been extended with two roles from Ansible Galaxy that set up Homebrew and its dependencies. Homebrew can then be used by other roles to install software and configure it.