### PR TITLE
Install dependencies from Ansible Galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Feel free to use it as inspiration and fork it.
 ## Getting Started
 
 The repository contains a [bootstrap script](bin/bootstrap) for macOS that can
-be run on a fresh machine. It installs [Homebrew] and [Ansible], and then runs
+be run on a fresh machine. It installs [Homebrew] and [Ansible], installs the
+required roles from [Ansible Galaxy](https://galaxy.ansible.com), and then runs
 the playbook with `ansible-pull`.
 
 Open a terminal and run the following command. You will be prompted for your

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -15,4 +15,11 @@ if ! command -v ansible-pull &>/dev/null; then
 	brew install ansible
 fi
 
+# Install dependencies
+requirements_file="/tmp/requirements.yml"
+curl -fsSL -o "${requirements_file}" "https://raw.githubusercontent.com/jdno/workstation/HEAD/requirements.yml"
+ansible-galaxy install -r "${requirements_file}"
+rm "${requirements_file}"
+
+# Run playbook
 ANSIBLE_FORCE_COLOR=1 ansible-pull -K -U https://github.com/jdno/workstation.git


### PR DESCRIPTION
The bootstrap script has been extended to first fetch the requirements file and install all roles from Ansible Galaxy. This ensures that the following run of ansible-pull will succeed.