### PR TITLE
Create role that configures the shell

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,3 +1,6 @@
 ---
 exclude_paths:
   - ~/.ansible
+
+skip_list:
+  - meta-no-info

--- a/bin/create-role
+++ b/bin/create-role
@@ -25,7 +25,7 @@ folders=(
 	meta
 )
 
-cd "${project_path}"
+cd "${project_path}/roles"
 
 mkdir "${module}"
 cd "${module}"

--- a/local.yml
+++ b/local.yml
@@ -5,3 +5,4 @@
   roles:
     - role: elliotweiser.osx-command-line-tools
     - role: geerlingguy.mac.homebrew
+    - role: shell

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Install zsh.
+  homebrew:
+    name: zsh
+    state: present
+
+- name: Install coreutils.
+  homebrew:
+    name: coreutils
+    state: present
+
+- name: Discover location of zsh executable.
+  ansible.builtin.command: which zsh
+  register: zsh
+  changed_when: false
+
+- name: Change default shell.
+  ansible.builtin.user:
+    name: "{{ ansible_user }}"
+    shell: "{{ zsh.stdout }}"
+  become: true
+
+- name: Copy configuration for zsh.
+  ansible.builtin.template:
+    src: zshrc.j2
+    dest: "{{ ansible_env['HOME'] }}/.zshrc"
+    mode: 0644

--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -1,0 +1,18 @@
+# The following lines were added by compinstall
+zstyle :compinstall filename '{{ ansible_env['HOME'] }}.zshrc'
+
+autoload -Uz compinit
+compinit
+# End of lines added by compinstall
+# Lines configured by zsh-newuser-install
+HISTFILE=~/.zsh_history
+HISTSIZE=1000
+SAVEHIST=1000
+setopt autocd
+bindkey -v
+# End of lines configured by zsh-newuser-install
+
+alias df="/bin/df -h"
+alias ll="gls -laGh --color --time-style=long-iso"
+alias ls="gls -Gh --color"
+alias path="echo $PATH | tr : '\n'"


### PR DESCRIPTION
A new role has been created that installs and configures the user's default shell. This is zsh, which runs with a pretty basic configuration and a few aliases.