### PR TITLE
Fix broken Ansible user variable

### DIFF
--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Change default shell.
   ansible.builtin.user:
-    name: "{{ ansible_user }}"
+    name: "{{ ansible_user_id }}"
     shell: "{{ zsh.stdout }}"
   become: true
 


### PR DESCRIPTION
The wrong Ansible variable was used in the shell role, which caused the role to fail and produce an error.