### PR TITLE
Enable syntax highlighting in zsh

### DIFF
--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -4,6 +4,11 @@
     name: zsh
     state: present
 
+- name: Install zsh-syntax-highlighting.
+  homebrew:
+    name: zsh-syntax-highlighting
+    state: present
+
 - name: Install coreutils.
   homebrew:
     name: coreutils

--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -1,5 +1,5 @@
 # The following lines were added by compinstall
-zstyle :compinstall filename '{{ ansible_env['HOME'] }}.zshrc'
+zstyle :compinstall filename '{{ ansible_env['HOME'] }}/.zshrc'
 
 autoload -Uz compinit
 compinit
@@ -16,3 +16,6 @@ alias df="/bin/df -h"
 alias ll="gls -laGh --color --time-style=long-iso"
 alias ls="gls -Gh --color"
 alias path="echo $PATH | tr : '\n'"
+
+# Must be the last instructions
+source {{ homebrew_prefix }}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
A new plugin for zsh has been added that enables syntax highlighting on the command line. The plugin is installed with Homebrew and then sourced in the zshrc.