### PR TITLE
Refactor zsh configuration to use ZDOTDIR

### DIFF
--- a/.github/workflows/push-shell.yml
+++ b/.github/workflows/push-shell.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Lint code with Shellcheck
         uses: ludeeus/action-shellcheck@1.1.0
+        env:
+          SHELLCHECK_OPTS: -e SC1071
 
   style:
     name: Check style

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     hooks:
       - id: shellcheck
         name: shellcheck
+        args: [-e, SC1071, -e, SC1091]
       - id: shfmt
         name: shfmt
   - repo: https://github.com/ansible/ansible-lint

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+zsh_config_dir: "{{ ansible_env['HOME'] }}/.config/zsh"

--- a/roles/shell/files/df.zsh
+++ b/roles/shell/files/df.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias df="/bin/df -h"

--- a/roles/shell/files/ll.zsh
+++ b/roles/shell/files/ll.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias ll="gls -laGh --color --time-style=long-iso"

--- a/roles/shell/files/ls.zsh
+++ b/roles/shell/files/ls.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias ls="gls -Gh --color"

--- a/roles/shell/files/path.zsh
+++ b/roles/shell/files/path.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias path="echo $PATH | tr : '\n'"

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -25,8 +25,29 @@
     shell: "{{ zsh.stdout }}"
   become: true
 
-- name: Copy configuration for zsh.
+- name: Create zsh configuration directory.
+  ansible.builtin.file:
+    path: "{{ zsh_config_dir }}"
+    owner: "{{ ansible_user_id }}"
+    state: directory
+    mode: 0700
+
+- name: Copy zshenv.
+  ansible.builtin.template:
+    src: zshenv.j2
+    dest: "{{ ansible_env['HOME'] }}/.zshenv"
+    mode: 0644
+
+- name: Copy zshrc.
   ansible.builtin.template:
     src: zshrc.j2
-    dest: "{{ ansible_env['HOME'] }}/.zshrc"
+    dest: "{{ zsh_config_dir }}/.zshrc"
     mode: 0644
+
+- name: Copy zsh aliases.
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ zsh_config_dir }}/{{ item | basename }}"
+    mode: 0644
+  with_fileglob:
+    - "files/*.zsh"

--- a/roles/shell/templates/zshenv.j2
+++ b/roles/shell/templates/zshenv.j2
@@ -1,0 +1,2 @@
+export EDITOR="vim"
+export ZDOTDIR="{{ zsh_config_dir }}"

--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -1,5 +1,5 @@
 # The following lines were added by compinstall
-zstyle :compinstall filename '{{ ansible_env['HOME'] }}/.zshrc'
+zstyle :compinstall filename '{{ zsh_config_dir }}/.zshrc'
 
 autoload -Uz compinit
 compinit
@@ -12,10 +12,9 @@ setopt autocd
 bindkey -v
 # End of lines configured by zsh-newuser-install
 
-alias df="/bin/df -h"
-alias ll="gls -laGh --color --time-style=long-iso"
-alias ls="gls -Gh --color"
-alias path="echo $PATH | tr : '\n'"
+for file in {{ zsh_config_dir }}/*.zsh; do
+    source "${file}"
+done
 
 # Must be the last instructions
-source {{ homebrew_prefix }}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source "{{ homebrew_prefix }}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"


### PR DESCRIPTION
The zsh configuration has been refactored to make liberal use of the `$ZDOTDIR` feature. Most importantly, other roles can now copy aliases or configuration into the directory.