### PR TITLE
Create role for Git

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -6,3 +6,4 @@
     - role: elliotweiser.osx-command-line-tools
     - role: geerlingguy.mac.homebrew
     - role: shell
+    - role: git

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+git_excludes_file: "{{ ansible_env['HOME'] }}/.gitignore_global"

--- a/roles/git/files/gc.zsh
+++ b/roles/git/files/gc.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias gc="git commit"

--- a/roles/git/files/gcane.zsh
+++ b/roles/git/files/gcane.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias gcane="git commit --amend --no-edit"

--- a/roles/git/files/gitignore_global
+++ b/roles/git/files/gitignore_global
@@ -1,0 +1,6 @@
+# macOS
+.DS_Store
+
+# IntelliJ
+.idea
+*.iml

--- a/roles/git/files/gp.zsh
+++ b/roles/git/files/gp.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias gp="git pull"

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew
+  - role: shell

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+- name: Install Git.
+  homebrew:
+    name: git
+    state: present
+
+- name: Configure default Git user name.
+  git_config:
+    name: user.name
+    scope: global
+    value: "{{ git.username }}"
+
+- name: Configure default Git user email.
+  git_config:
+    name: user.email
+    scope: global
+    value: "{{ git.email }}"
+
+- name: Configure default PGP signing key.
+  git_config:
+    name: user.signingkey
+    scope: global
+    value: "{{ git.signing_key }}"
+
+- name: Create global excludes file.
+  ansible.builtin.copy:
+    src: gitignore_global
+    dest: "{{ git_excludes_file }}"
+    mode: 0644
+
+- name: Set global excludes file.
+  git_config:
+    name: core.excludesfile
+    scope: global
+    value: "{{ git_excludes_file }}"
+
+- name: Enable signing commits.
+  git_config:
+    name: commit.gpgsign
+    scope: global
+    value: true
+
+- name: Set current branch as default push target.
+  git_config:
+    name: push.default
+    scope: global
+    value: current
+
+- name: Enable pushing tags with their associated commits.
+  git_config:
+    name: push.followTags
+    scope: global
+    value: true
+
+- name: Copy Git aliases.
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ zsh_config_dir }}/{{ item | basename }}"
+    mode: 0644
+  with_fileglob:
+    - "files/*.zsh"

--- a/roles/git/vars/main.yml
+++ b/roles/git/vars/main.yml
@@ -1,0 +1,5 @@
+---
+git:
+  username: "Jan David"
+  email: "jdno@jdno.dev"
+  signing_key: "DC589F50FB7E8B29"


### PR DESCRIPTION
A new role has been created that installs and configures Git. Finishing the configuration still requires a manual action at the moment, which is to copy the GPG keys that are used for code signing. This can hopefully be automated as well in a future change.