### PR TITLE
Create role for neovim

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -7,3 +7,4 @@
     - role: geerlingguy.mac.homebrew
     - role: shell
     - role: git
+    - role: neovim

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -22,6 +22,12 @@
     scope: global
     value: "{{ git.signing_key }}"
 
+- name: Configure editor for commit messages.
+  git_config:
+    name: core.editor
+    scope: global
+    value: vim
+
 - name: Create global excludes file.
   ansible.builtin.copy:
     src: gitignore_global

--- a/roles/neovim/defaults/main.yml
+++ b/roles/neovim/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+neovim_config_directory: "{{ ansible_env['HOME'] }}/.config/nvim"

--- a/roles/neovim/files/init.vim
+++ b/roles/neovim/files/init.vim
@@ -1,0 +1,13 @@
+" Disable Arrow keys in Escape mode
+map <up> <nop>
+map <down> <nop>
+map <left> <nop>
+map <right> <nop>
+
+set number relativenumber
+
+augroup numbertoggle
+  autocmd!
+  autocmd BufEnter,FocusGained,InsertLeave * set relativenumber
+  autocmd BufLeave,FocusLost,InsertEnter   * set norelativenumber
+augroup END

--- a/roles/neovim/files/neovim.zsh
+++ b/roles/neovim/files/neovim.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+
+# Export neovim as the default editor
+export EDITOR="nvim"
+
+# Alias neovim to vim
+alias vim="nvim"

--- a/roles/neovim/meta/main.yml
+++ b/roles/neovim/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew
+  - role: shell

--- a/roles/neovim/tasks/main.yml
+++ b/roles/neovim/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install neovim.
+  homebrew:
+    name: neovim
+    state: present
+
+- name: Ensure neovim config directory exists.
+  ansible.builtin.file:
+    path: "{{ neovim_config_directory }}"
+    owner: "{{ ansible_user_id }}"
+    state: directory
+    mode: 0700
+
+- name: Copy neovim configuration.
+  ansible.builtin.copy:
+    src: "init.vim"
+    dest: "{{ neovim_config_directory }}/init.vim"
+
+- name: Set neovim as default editor.
+  ansible.builtin.copy:
+    src: "neovim.zsh"
+    dest: "{{ zsh_config_dir }}/neovim.zsh"

--- a/roles/shell/templates/zshenv.j2
+++ b/roles/shell/templates/zshenv.j2
@@ -1,2 +1,1 @@
-export EDITOR="vim"
 export ZDOTDIR="{{ zsh_config_dir }}"


### PR DESCRIPTION
A new role has been created that installs and configures neovim. It is used as a replacement for vim.