### PR TITLE
Create role for SSH

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,6 +5,4 @@ rules:
   braces:
     min-spaces-inside: 1
     max-spaces-inside: 1
-  line-length:
-    ignore: |
-      .github/workflows/*
+  line-length: false

--- a/local.yml
+++ b/local.yml
@@ -6,6 +6,7 @@
     - { role: elliotweiser.osx-command-line-tools, tags: ["base"] }
     - { role: geerlingguy.mac.homebrew, tags: ["base"] }
     - { role: ansible, tags: ["base"] }
+    - { role: ssh, tags: ["base", "terminal"] }
     - { role: shell, tags: ["base", "terminal"] }
-    - { role: git, tags: ["base", "terminal", "dev"] }
     - { role: neovim, tags: ["base", "terminal"] }
+    - { role: git, tags: ["base", "terminal", "dev"] }

--- a/roles/ssh/files/config
+++ b/roles/ssh/files/config
@@ -1,0 +1,2 @@
+Host *
+  IdentityAgent "~/.1password/agent.sock"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Copy configuration for SSH.
+  ansible.builtin.copy:
+    src: config
+    dest: "{{ ansible_env['HOME'] }}/.ssh/config"
+    mode: 0600
+
+- name: Create directory for 1Password SSH Agent socket.
+  ansible.builtin.file:
+    path: "{{ ansible_env['HOME'] }}/.1password"
+    state: directory
+    mode: 0700
+
+- name: Symlink 1Password SSH Agent socket.
+  ansible.builtin.file:
+    src: "{{ ansible_env['HOME'] }}/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+    dest: "{{ ansible_env['HOME'] }}/.1password/agent.sock"
+    state: link


### PR DESCRIPTION
A new role has been created that configures SSH. The SSH executable is shipped with macOS by default. Since the SSH agent inside 1Password is used, the configuration simply links to its socket.