### PR TITLE
Create role for Rust

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -3,10 +3,16 @@
   connection: local
 
   roles:
+    # Set up tools
     - { role: elliotweiser.osx-command-line-tools, tags: ["base"] }
     - { role: geerlingguy.mac.homebrew, tags: ["base"] }
     - { role: ansible, tags: ["base"] }
+
+    # Configure terminal applications
     - { role: ssh, tags: ["base", "terminal"] }
     - { role: shell, tags: ["base", "terminal"] }
     - { role: neovim, tags: ["base", "terminal"] }
     - { role: git, tags: ["base", "terminal", "dev"] }
+
+    # Install programming languages
+    - { role: rust, tags: ["terminal", "dev"] }

--- a/roles/rust/meta/main.yml
+++ b/roles/rust/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Rust programming language.
+  homebrew:
+    name: rust
+    state: present


### PR DESCRIPTION
A new role has been created that installs the Rust programming language. No configuration is required yet, but because this might change we are creating a dedicated role for Rust.