### PR TITLE
Create role for macOS software

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -16,3 +16,6 @@
 
     # Install programming languages
     - { role: rust, tags: ["terminal", "dev"] }
+
+    # Install applications
+    - { role: software, tags: ["workstation"] }

--- a/roles/software/meta/main.yml
+++ b/roles/software/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew
+  - role: geerlingguy.mac.mas

--- a/roles/software/tasks/main.yml
+++ b/roles/software/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Tap cask-drivers repository.
+  community.general.homebrew_tap:
+    name: homebrew/cask-drivers
+    state: present
+
+- name: Install applications through Homebrew.
+  homebrew:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ formulae }}"
+
+- name: Install applications through Homebrew Cask.
+  homebrew_cask:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ casks }}"
+
+- name: Install applications from Mac App Store.
+  ansible.builtin.import_role:
+    name: geerlingguy.mac.mas
+  vars:
+    mas_installed_apps: "{{ mac_store_apps }}"

--- a/roles/software/vars/main.yml
+++ b/roles/software/vars/main.yml
@@ -1,0 +1,27 @@
+---
+formulae:
+  - gifski
+
+casks:
+  - 1password
+  - alfred
+  - bartender
+  - betterdummy
+  - camo-studio
+  - discord
+  - docker
+  - firefox
+  - hey
+  - jetbrains-toolbox
+  - keka
+  - signal
+  - spotify
+  - warp
+  - yubico-yubikey-manager
+
+mac_store_apps:
+  - { id: 1569813296, name: "1Password for Safari" }
+  - { id: 441258766, name: "Magnet" }
+  - { id: 1289197285, name: "MindNode" }
+  - { id: 1346203938, name: "OmniFocus" }
+  - { id: 406825478, name: "Telephone" }


### PR DESCRIPTION
A new role has been created that installs the software and applications
that I am commonly using. These are all installed through either
Homebrew or the Mac App Store.