### PR TITLE
Create role to cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ before Ansible can succeed. The [bootstrap script](bin/bootstrap) and the
 [Ansible script](bin/ansible-playbook) ensure that these conditions are met. If
 you run the playbook directly, ensure that the following resources exist:
 
-- The `gpg` executable must be in the `$PATH`
-- The user must be signed into an active session in the [1Password CLI]
+- The user must be signed into the Mac App Store.
+- The user must be signed into an active session in the [1Password CLI].
+- The `gpg` executable must be in the `$PATH`.
 
 ## Secrets
 

--- a/local.yml
+++ b/local.yml
@@ -19,3 +19,6 @@
 
     # Install applications
     - { role: software, tags: ["workstation"] }
+
+    # Cleanup
+    - { role: cleanup, tags: ["workstation"] }

--- a/roles/cleanup/meta/main.yml
+++ b/roles/cleanup/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.mac.homebrew
+  - role: geerlingguy.mac.mas

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install applications from Mac App Store.
+  ansible.builtin.import_role:
+    name: geerlingguy.mac.mas
+  vars:
+    mas_uninstalled_apps: "{{ mac_store_apps }}"

--- a/roles/cleanup/vars/main.yml
+++ b/roles/cleanup/vars/main.yml
@@ -1,0 +1,5 @@
+---
+mac_store_apps:
+  - { id: 682658836, name: "GarageBand" }
+  - { id: 408981434, name: "iMovie" }
+  - { id: 409183694, name: "Keynote" }


### PR DESCRIPTION
A new role has been created that removes pre-installed or no longer necessary software. It can also be extended in the future to cover other tools that are no longer required, for example from Homebrew.