### PR TITLE
De-conflict Ansible variable names

### DIFF
--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Install applications from Mac App Store.
+- name: Uninstall applications from Mac App Store.
   ansible.builtin.import_role:
     name: geerlingguy.mac.mas
   vars:
-    mas_uninstalled_apps: "{{ mac_store_apps }}"
+    mas_uninstalled_apps: "{{ uninstall_mac_store_apps }}"

--- a/roles/cleanup/vars/main.yml
+++ b/roles/cleanup/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-mac_store_apps:
+uninstall_mac_store_apps:
   - { id: 682658836, name: "GarageBand" }
   - { id: 408981434, name: "iMovie" }
   - { id: 409183694, name: "Keynote" }

--- a/roles/software/tasks/main.yml
+++ b/roles/software/tasks/main.yml
@@ -8,16 +8,16 @@
   homebrew:
     name: "{{ item }}"
     state: present
-  with_items: "{{ formulae }}"
+  with_items: "{{ install_formulae }}"
 
 - name: Install applications through Homebrew Cask.
   homebrew_cask:
     name: "{{ item }}"
     state: present
-  with_items: "{{ casks }}"
+  with_items: "{{ install_casks }}"
 
 - name: Install applications from Mac App Store.
   ansible.builtin.import_role:
     name: geerlingguy.mac.mas
   vars:
-    mas_installed_apps: "{{ mac_store_apps }}"
+    mas_installed_apps: "{{ install_mac_store_apps }}"

--- a/roles/software/vars/main.yml
+++ b/roles/software/vars/main.yml
@@ -1,8 +1,8 @@
 ---
-formulae:
+install_formulae:
   - gifski
 
-casks:
+install_casks:
   - 1password
   - alfred
   - bartender
@@ -19,7 +19,7 @@ casks:
   - warp
   - yubico-yubikey-manager
 
-mac_store_apps:
+install_mac_store_apps:
   - { id: 1569813296, name: "1Password for Safari" }
   - { id: 441258766, name: "Magnet" }
   - { id: 1289197285, name: "MindNode" }


### PR DESCRIPTION
When copy & pasting the task to run the Mac App Store role, the variable name for the list of files has not been changed. This has been fixed now.