### PR TITLE
Enable syntax highlighting in neovim

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -26,7 +26,7 @@
   git_config:
     name: core.editor
     scope: global
-    value: vim
+    value: nvim
 
 - name: Create global excludes file.
   ansible.builtin.copy:

--- a/roles/neovim/files/init.vim
+++ b/roles/neovim/files/init.vim
@@ -1,3 +1,7 @@
+" Enable syntax highlighting
+syntax on
+filetype on
+
 " Disable Arrow keys in Escape mode
 map <up> <nop>
 map <down> <nop>


### PR DESCRIPTION
The configuration for neovim has been extended to enable syntax highlighting by default. Furthermore, neovim has been made the editor for Git so that we get syntax highlighting and auto-linebreaks by default.