### PR TITLE
Remove cleanup role

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -19,6 +19,3 @@
 
     # Install applications
     - { role: software, tags: ["workstation"] }
-
-    # Cleanup
-    - { role: cleanup, tags: ["workstation"] }

--- a/roles/cleanup/meta/main.yml
+++ b/roles/cleanup/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew
-  - role: geerlingguy.mac.mas

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -1,6 +1,0 @@
----
-- name: Uninstall applications from Mac App Store.
-  ansible.builtin.import_role:
-    name: geerlingguy.mac.mas
-  vars:
-    mas_uninstalled_apps: "{{ uninstall_mac_store_apps }}"

--- a/roles/cleanup/vars/main.yml
+++ b/roles/cleanup/vars/main.yml
@@ -1,5 +1,0 @@
----
-uninstall_mac_store_apps:
-  - { id: 682658836, name: "GarageBand" }
-  - { id: 408981434, name: "iMovie" }
-  - { id: 409183694, name: "Keynote" }


### PR DESCRIPTION
The cleanup role has been removed again due to an issue with the MAS command-line utility. Uninstalling apps requires sudo priviledges, but even running the CLI as sudo does not help [^1].

[^1]: https://github.com/mas-cli/mas/issues/216