### PR TITLE
Fix path for Git repositories

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Clone Git repository.
   ansible.builtin.git:
     repo: "https://github.com/{{ project.repo.owner }}/{{ project.repo.name }}.git"
-    dest: repo_directory
+    dest: "{{ repo_directory.path }}"
   register: git_clone_result
   failed_when: "'Local modifications exist in repository' not in git_clone_result.msg"
 


### PR DESCRIPTION
The path for Git repositories was passed as a string and not as a variable, resulting in a directory in the playbook directory into which all repositories got cloned. This has been fixed, and repositories now correctly end up inside the Developer folder.