### PR TITLE
Create directory for SSH configuration

### DIFF
--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create directory for SSH configuration.
+  ansible.builtin.file:
+    path: "{{ ansible_env['HOME'] }}/.ssh"
+    state: directory
+    mode: 0700
+
 - name: Copy configuration for SSH.
   ansible.builtin.copy:
     src: config


### PR DESCRIPTION
The directory for the SSH configuration does not exist on a fresh machine, thus it needs to be created manually.