### PR TITLE
Hotfix repository role

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -18,7 +18,7 @@
     repo: "https://github.com/{{ project.repo.owner }}/{{ project.repo.name }}.git"
     dest: "{{ repo_directory.path }}"
   register: git_clone_result
-  failed_when: "'Local modifications exist in repository' not in git_clone_result.msg"
+  ignore_errors: true # noqa ignore-errors
 
 - name: Configure default Git user email.
   git_config:


### PR DESCRIPTION
The repository role failed to execute with a rather weird error. Apparently, the result object didn't have a `msg` key. This might be caused by the loop, but I have no idea how to properly fix it. So we're hotfixing the issue for the time being by ignoring all errors.