### PR TITLE
Source brew when creating shell session

### DIFF
--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -1,3 +1,8 @@
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# https://docs.brew.sh/Shell-Completion
+FPATH="{{ homebrew_prefix }}/share/zsh/site-functions:${FPATH}"
+
 # The following lines were added by compinstall
 zstyle :compinstall filename '{{ zsh_config_dir }}/.zshrc'
 


### PR DESCRIPTION
Brew was never sourced when opening a new shell, and thus brew and the tools installed through it were not available to the user.