### PR TITLE
Install Rust through the toolchain installer

### DIFF
--- a/roles/rust/files/rust.zsh
+++ b/roles/rust/files/rust.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+source $HOME/.cargo/env

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
-- name: Install Rust programming language.
+- name: Install the Rust toolchain installer.
   homebrew:
-    name: rust
+    name: rustup-init
     state: present
+
+- name: Install the latest Rust stable toolchain.
+  ansible.builtin.command: rustup-init -y -c cargo rustfmt clippy
+
+- name: Add Rust to the PATH
+  ansible.builtin.copy:
+    src: "rust.zsh"
+    dest: "{{ zsh_config_dir }}/rust.zsh"


### PR DESCRIPTION
The role for Rust has been changed to install Rust through the toolchain installer and not Homebrew. Most notably, this ensures that a toolchain is available on the local machine for the CLion IDE.