### PR TITLE
Ensure ansible-lint runs on GitHub Actions

### DIFF
--- a/.github/workflows/push-ansible.yml
+++ b/.github/workflows/push-ansible.yml
@@ -4,7 +4,7 @@ name: Ansible
 "on":
   push:
     paths:
-      - "roles/"
+      - "roles/**"
       - "ansible.cfg"
       - "hosts"
       - "local.yml"


### PR DESCRIPTION
The configuration for the Ansible lint action has been slightly tweaked to ensure that ansible-lint runs properly whenever a role or playbook changes.