### PR TITLE
Avoid running dependency roles twice

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -3,9 +3,7 @@
   connection: local
 
   roles:
-    # Set up tools
-    - { role: elliotweiser.osx-command-line-tools, tags: ["base"] }
-    - { role: geerlingguy.mac.homebrew, tags: ["base"] }
+    # Set up Ansible
     - { role: ansible, tags: ["base"] }
 
     # Configure terminal applications


### PR DESCRIPTION
The two roles that were run first in the playbook are also pulled in by other roles as dependencies. This caused them to run twice, which is absolutely not necessary.