### PR TITLE
Install ansible-lint

### DIFF
--- a/roles/ansible/tasks/main.yml
+++ b/roles/ansible/tasks/main.yml
@@ -4,6 +4,11 @@
     name: ansible
     state: present
 
+- name: Install ansible-lint.
+  homebrew:
+    name: ansible-lint
+    state: present
+
 - name: Install Python3.
   homebrew:
     name: python@3.10


### PR DESCRIPTION
The Ansible role has been extended to also install ansible-lint, which we use to check this playbook for common errors or mistakes.