### PR TITLE
Disable vi mode in zsh

### DIFF
--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -14,7 +14,6 @@ HISTFILE=~/.zsh_history
 HISTSIZE=1000
 SAVEHIST=1000
 setopt autocd
-bindkey -v
 # End of lines configured by zsh-newuser-install
 
 for file in {{ zsh_config_dir }}/*.zsh; do


### PR DESCRIPTION
The vi mode in zsh doesn't work well inside the IntelliJ IDE, where the ESC key closes the terminal window.