### PR TITLE
Remove dependencies from roles

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -3,6 +3,9 @@
   connection: local
 
   roles:
+    # Set up tooling
+    - { role: geerlingguy.mac.homebrew, tags: ["base"] }
+
     # Set up Ansible
     - { role: ansible, tags: ["base"] }
 

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew
-  - role: shell

--- a/roles/neovim/meta/main.yml
+++ b/roles/neovim/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew
-  - role: shell

--- a/roles/repository/meta/main.yml
+++ b/roles/repository/meta/main.yml
@@ -1,5 +1,0 @@
----
-dependencies:
-  - role: git
-  - role: rust
-  - role: software

--- a/roles/rust/meta/main.yml
+++ b/roles/rust/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew

--- a/roles/software/meta/main.yml
+++ b/roles/software/meta/main.yml
@@ -1,4 +1,0 @@
----
-dependencies:
-  - role: geerlingguy.mac.homebrew
-  - role: geerlingguy.mac.mas


### PR DESCRIPTION
The dependencies in roles didn't work as I expected, with the result that some roles where run quite a few times over the whole execution of the playbook. Even though most changes were only applied once, running through all of them took a lot of time.