### PR TITLE
Install Balsamiq Wireframes

### DIFF
--- a/roles/software/vars/main.yml
+++ b/roles/software/vars/main.yml
@@ -8,6 +8,7 @@ install_casks:
   - 1password
   - affinity-designer
   - alfred
+  - balsamiq-wireframes
   - bartender
   - betterdummy
   - camo-studio


### PR DESCRIPTION
Balsamiq is a tool for quick prototyping and wireframing.