### PR TITLE
Replace Git with Graphite

### DIFF
--- a/roles/git/files/gc.zsh
+++ b/roles/git/files/gc.zsh
@@ -1,2 +1,0 @@
-#!/usr/bin/env zsh
-alias gc="git commit"

--- a/roles/git/files/gcane.zsh
+++ b/roles/git/files/gcane.zsh
@@ -1,2 +1,0 @@
-#!/usr/bin/env zsh
-alias gcane="git commit --amend --no-edit"

--- a/roles/git/files/git.zsh
+++ b/roles/git/files/git.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias git="echo \"Did you mean gt?\""

--- a/roles/git/files/gp.zsh
+++ b/roles/git/files/gp.zsh
@@ -1,2 +1,0 @@
-#!/usr/bin/env zsh
-alias gp="git pull"

--- a/roles/git/files/graphite.zsh
+++ b/roles/git/files/graphite.zsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+
+#compdef gt
+###-begin-gt-completions-###
+#
+# yargs command completion script
+#
+# Installation: /opt/homebrew/bin/gt completion >> ~/.zshrc
+#    or /opt/homebrew/bin/gt completion >> ~/.zprofile on OSX.
+#
+_gt_yargs_completions() {
+	local reply
+	local si=$IFS
+	IFS=$''
+	reply=($(COMP_CWORD="$((CURRENT - 1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" /opt/homebrew/bin/gt --get-yargs-completions "${words[@]}"))
+	IFS=$si
+	_describe 'values' reply
+}
+compdef _gt_yargs_completions gt
+###-end-gt-completions-###

--- a/roles/git/files/sudogit.zsh
+++ b/roles/git/files/sudogit.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias sudogit="/opt/homebrew/bin/git"

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -58,6 +58,12 @@
     scope: global
     value: true
 
+- name: Install Graphite.
+  community.general.npm:
+    name: "@withgraphite/graphite-cli"
+    global: yes
+    state: present
+
 - name: Copy Git aliases.
   ansible.builtin.copy:
     src: "{{ item }}"

--- a/roles/software/vars/main.yml
+++ b/roles/software/vars/main.yml
@@ -4,6 +4,8 @@ install_formulae:
   - gh
   - gifski
   - pre-commit
+  - shellcheck
+  - shfmt
 
 install_casks:
   - 1password


### PR DESCRIPTION
Graphite is a new command-line tool that implements stacked commits. It
can proxy Git, so we have created an alias that prevents accidental use
of Git.