### PR TITLE
Register Homebrew prefix in fact

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -4,16 +4,14 @@
 
   roles:
     # Set up tooling
-    - { role: geerlingguy.mac.homebrew, tags: ["base"] }
-
-    # Set up Ansible
+    - { role: homebrew, tags: ["base"] }
     - { role: ansible, tags: ["base"] }
 
     # Configure terminal applications
-    - { role: ssh, tags: ["base", "terminal"] }
-    - { role: shell, tags: ["base", "terminal"] }
-    - { role: neovim, tags: ["base", "terminal"] }
-    - { role: git, tags: ["base", "terminal", "dev"] }
+    - { role: ssh, tags: ["terminal"] }
+    - { role: shell, tags: ["terminal"] }
+    - { role: neovim, tags: ["terminal"] }
+    - { role: git, tags: ["terminal", "dev"] }
 
     # Install programming languages and tools
     - { role: aws, tags: ["terminal", "dev"] }

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install Homebrew.
+  ansible.builtin.include_role:
+    name: geerlingguy.mac.homebrew
+
+- name: Print Homebrew prefix.
+  ansible.builtin.command:
+    cmd: brew --prefix
+  register: brew_prefix
+  changed_when: false
+
+- name: Set Homebrew prefix as fact.
+  ansible.builtin.set_fact:
+    brew_prefix: "{{ brew_prefix.stdout }}"


### PR DESCRIPTION
A new fact containing the Homebrew prefix is being registered. This makes the playbook more robust when running on different versions of macOS and Homebrew.