### PR TITLE
Remove Graphite

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -58,12 +58,6 @@
     scope: global
     value: true
 
-- name: Install Graphite.
-  community.general.npm:
-    name: "@withgraphite/graphite-cli"
-    global: yes
-    state: present
-
 - name: Copy Git aliases.
   ansible.builtin.template:
     src: "{{ item }}"


### PR DESCRIPTION
Graphite has been removed from the Git role. For one, its installation required Node, which wasn't available at that time in the playbook. But maybe more importantly, we are not convinced by the value of the tool.