### PR TITLE
Automatically set up remote branch in Git

### DIFF
--- a/roles/git/templates/gitconfig.j2
+++ b/roles/git/templates/gitconfig.j2
@@ -12,5 +12,6 @@
 [pull]
         rebase = True
 [push]
+        autoSetupRemote = true
         default = current
         followTags = True


### PR DESCRIPTION
The Git config has been extended to automatically set up a remote branch when creating a local one.