### PR TITLE
Sign Git commits with an SSH key

### DIFF
--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 git_excludes_file: "{{ ansible_env['HOME'] }}/.gitignore_global"
+git_user:
+  username: "Jan David"
+  email: "jdno@jdno.dev"
+  signing_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoH6CKep+6D+kqOQ+XJLY6fA/jGZ4hV934/wRX8mZBC"

--- a/roles/git/templates/gitconfig.j2
+++ b/roles/git/templates/gitconfig.j2
@@ -7,6 +7,10 @@
         excludesfile = {{ ansible_env['HOME'] }}/.gitignore_global
 [commit]
         gpgsign = True
+[gpg]
+        format = ssh
+[gpg "ssh"]
+        program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
 [init]
         defaultBranch = main
 [pull]

--- a/roles/git/vars/main.yml
+++ b/roles/git/vars/main.yml
@@ -1,5 +1,1 @@
 ---
-git_user:
-  username: "Jan David"
-  email: "jdno@jdno.dev"
-  signing_key: "DC589F50FB7E8B29"


### PR DESCRIPTION
Signing Git commits with an SSH key and the 1Password integration is much more convenient than using the YubiKey. The Git config has been updated to use the CLI provided by 1Password.